### PR TITLE
Facing problems with non expected secrets

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -6,7 +6,7 @@ to_update=0
 meshNetworks="networks:"
 
 # foreach remote cluster
-for remote_secret in $(kubectl get secrets -n istio-system -o=name | grep remote-secret); do
+for remote_secret in $(kubectl get secrets -n istio-system -o=name --field-selector type=Opaque | grep remote-secret); do
     echo "Getting cluster name for remote cluster from $remote_secret"
     remote_cluster_name=$(kubectl get "$remote_secret" -n istio-system -o jsonpath='{.metadata.annotations.networking\.istio\.io/cluster}')
     echo "Got cluster name: $remote_cluster_name"


### PR DESCRIPTION
This workaround was listing an unexpected secret and assuming it was an kubeconfig: secret/istio-reader-service-account-istio-remote-secret-token. The result was the cron fails:

```bash
Getting cluster name for remote cluster from secret/istio-reader-service-account-istio-remote-secret-token
Got cluster name: 
Getting kubeconfig for remote cluster from secret/istio-reader-service-account-istio-remote-secret-token
Got kubeconfig
Getting eastwestgateway's hostname
error: error loading config file "/tmp/kubeconfig": couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }
```

After inspecting the secrets, I found the ofensor and I was able to skip it by its `type`:

```bash
kubectl get secrets -n istio-system
NAME                                                     TYPE                                  DATA   AGE
cacerts                                                  Opaque                                4      5d5h
istio-ca-secret                                          istio.io/ca-root                      5      7d5h
istio-reader-service-account-istio-remote-secret-token   kubernetes.io/service-account-token   3      6d2h
istio-remote-secret-platform-arquitetura                 Opaque                                1      5d5h
```

Using the secret type, I was able to skip this invalid secret using the filter `--field-selector type=Opaque`
